### PR TITLE
Fix bug observed while plotting dot plots with small number of samples

### DIFF
--- a/uadapy/plotting/plots1D.py
+++ b/uadapy/plotting/plots1D.py
@@ -20,7 +20,7 @@ def calculate_offsets(count, max_count):
 
 def calculate_dot_size(num_samples, scale_factor):
     if num_samples < 100:
-        dot_size = 3.125
+        dot_size = scale_factor * 3.125
     else:
         dot_size = scale_factor * (50 /(4 ** np.log10(num_samples)))
     return dot_size
@@ -202,7 +202,10 @@ def plot_1d_distribution(distributions, num_samples, plot_types:list, seed=55, f
                             dot_size = kwargs['dot_size']
                     if 'stripplot' in plot_types:
                         if 'dot_size' not in kwargs:
-                            scale_factor = 1 + np.log10(num_samples/100)
+                            if num_samples < 100:
+                                scale_factor = 1
+                            else:
+                                scale_factor = 1 + np.log10(num_samples/100)
                             dot_size = calculate_dot_size(len(sample[:,index]), scale_factor)
                         if kwargs.get('vert',True):
                             sns.stripplot(x=[k]*len(sample[:,index]), y=sample[:,index], color=palette[k % len(palette)], size=dot_size, jitter=0.25, ax=ax)


### PR DESCRIPTION
scale factor was not taken into account when computing dot sizes when samples were less than 100. Correction has been made.

Sample code:
import uadapy.data as data
import uadapy.dr.uapca as uapca
import uadapy.plotting.plots1D as plots1D

distribs_hi = data.load_iris_normal()
distribs_lo = uapca(distribs_hi, dims=2)
fig, axs = plots1D.plot_1d_distribution(distribs_lo, 50, ['dotplot'], titles=["Dimension 1" ,"Dimension 2"])

Result:
![Figure_1](https://github.com/user-attachments/assets/0bd2411c-b5d8-4d23-9715-6daa20e6033f)

Resolves Issue https://github.com/UniStuttgart-VISUS/uadapy/issues/14

