### PR TITLE
Update documentation for time series plus general documentation updates

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -3,6 +3,8 @@ Examples
 ========
 
 The following jupyter notebooks contain examples on how to use the library.
+Dimensionality reduction
+========================
 
 Uncertainty-aware multidimensional scaling
 ------------------------------------------
@@ -14,12 +16,56 @@ Uncertainty-aware principal component analysis
 
 `Load data, reduce the dimensionality with UAPCA, visualize the output <https://github.com/UniStuttgart-VISUS/uadapy/blob/main/examples/uapca.ipynb>`_
 
+Uncertainty-aware PCA revisited
+-------------------------------
+ 
+`Apply the sample-based formulation of uncertainty-aware PCA to the example data of the paper "Uncertainty-Aware PCA Revisited" <https://github.com/UniStuttgart-VISUS/uadapy/blob/main/examples/uapca_revisited.ipynb>`_
+
+Uncertainty-aware PCA for Gaussian mixture models
+-------------------------------------------------
+ 
+`Project Gaussian mixture model distributions with wGMM-UAPCA and visualize the output <https://github.com/UniStuttgart-VISUS/uadapy/blob/main/examples/wgmm_uapca.ipynb>`_
+
+Interactive weight exploration for UAPCA
+----------------------------------------
+ 
+`Interactively explore how different weight configurations affect UAPCA and wGMM-UAPCA projections <https://github.com/UniStuttgart-VISUS/uadapy/blob/main/examples/interactive_weights_uapca.ipynb>`_
+
+VIPurPCA
+-----------------------------------
+ 
+`Propagate distributional uncertainty through the PCA pipeline with VIPurPCA on synthetic test distributions <https://github.com/UniStuttgart-VISUS/uadapy/blob/main/examples/vipurpca.ipynb>`_
+
+Time series analysis
+====================
+
 Uncertainty-aware seasonal trend decomposition with LOESS
 ----------------------------------------------
 
-`Load data, reduce the dimensionality with UAPCA, visualize the output <https://github.com/UniStuttgart-VISUS/uadapy/blob/main/examples/uastl.ipynb>`_
+`Load data, visualize a time series, apply UASTL, visualize the output <https://github.com/UniStuttgart-VISUS/uadapy/blob/main/examples/uastl.ipynb>`_
 
+Uncertainty-aware Fourier analysis
+----------------------------------
+ 
+`Perform an uncertainty-aware spectral analysis of an uncertain time series <https://github.com/UniStuttgart-VISUS/uadapy/blob/main/examples/uafourier.ipynb>`_
+
+Visualization techniques
+========================
+ 
+Stippling
+---------
+ 
+`Visualize uncertain 2D projections using stippling <https://github.com/UniStuttgart-VISUS/uadapy/blob/main/examples/stippling.ipynb>`_
+ 
+Working with data
+=================
+ 
 Working with own data
 ---------------------
-
+ 
 `Load data, create a distribution, visualize it <https://github.com/UniStuttgart-VISUS/uadapy/blob/main/examples/ownData.ipynb>`_
+ 
+Provided example datasets
+-------------------------
+ 
+`Overview of the ready-to-use toy datasets shipped with the library <https://github.com/UniStuttgart-VISUS/uadapy/blob/main/examples/datasets.ipynb>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ This section is currently work in progress and will be extended over time.
    :maxdepth: 1
 
    distribution.rst
+   timeseries.rst
 
 Indices and tables
 ==================

--- a/docs/timeseries.rst
+++ b/docs/timeseries.rst
@@ -14,7 +14,7 @@ Creating a time series
 
 :Parameters:
    - **model**: A `scipy.stats` distribution object or an array of samples.
-   - **timesteps** *(int)*: The number of time steps in the time series.
+   - **timesteps** *(np.ndarray, optional)*: The time steps in the time series (if None, a default time axis is generated).
    - **name** *(str, optional)*: The name of the distribution (default is inferred from the model).
    - **n_dims** *(int, optional)*: Dimensionality of the distribution (default is `1`).
 
@@ -61,7 +61,7 @@ Creating correlated distributions
 
 :Parameters:
    - **distributions** *(list[Distribution])*: A list of individual distributions or time series.
-   - **covariance_matrix** *(np.ndarray, optional)*: The pairwise covariance matrix of the distributions.
+   - **covariance_matrix** *(np.ndarray)*: The pairwise covariance matrix of the distributions.
 
 The class validates whether the provided covariance matrix aligns with the variances of the individual distributions.
 

--- a/docs/uadapy.data.data.rst
+++ b/docs/uadapy.data.data.rst
@@ -1,0 +1,7 @@
+uadapy.data.data module
+=======================
+
+.. automodule:: uadapy.data.data
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.data.rst
+++ b/docs/uadapy.data.rst
@@ -1,10 +1,18 @@
 uadapy.data package
-=======================
+===================
 
-uadapy.data.data module
------------------------------------------
+Submodules
+----------
 
-.. automodule:: uadapy.data.data
+.. toctree::
+   :maxdepth: 4
+
+   uadapy.data.data
+
+Module contents
+---------------
+
+.. automodule:: uadapy.data
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.distribution.rst
+++ b/docs/uadapy.distribution.rst
@@ -1,0 +1,7 @@
+uadapy.distribution module
+==========================
+
+.. automodule:: uadapy.distribution
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.distributions.chi_square_comb.rst
+++ b/docs/uadapy.distributions.chi_square_comb.rst
@@ -1,0 +1,7 @@
+uadapy.distributions.chi\_square\_comb module
+=============================================
+
+.. automodule:: uadapy.distributions.chi_square_comb
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.distributions.multivariate_gmm.rst
+++ b/docs/uadapy.distributions.multivariate_gmm.rst
@@ -1,0 +1,7 @@
+uadapy.distributions.multivariate\_gmm module
+=============================================
+
+.. automodule:: uadapy.distributions.multivariate_gmm
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.distributions.rst
+++ b/docs/uadapy.distributions.rst
@@ -1,0 +1,19 @@
+uadapy.distributions package
+============================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   uadapy.distributions.chi_square_comb
+   uadapy.distributions.multivariate_gmm
+
+Module contents
+---------------
+
+.. automodule:: uadapy.distributions
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.dr.rst
+++ b/docs/uadapy.dr.rst
@@ -1,27 +1,22 @@
 uadapy.dr package
 =================
 
+Submodules
+----------
 
-uadapy.dr.uamds module
-----------------------
+.. toctree::
+   :maxdepth: 4
 
-.. automodule:: uadapy.dr.uamds
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-uadapy.dr.uapca module
-----------------------
-
-.. automodule:: uadapy.dr.uapca
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   uadapy.dr.uamds
+   uadapy.dr.uapca
+   uadapy.dr.uapca_revisited
+   uadapy.dr.vipurpca
+   uadapy.dr.wgmm_uapca
 
 Module contents
 ---------------
 
 .. automodule:: uadapy.dr
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.dr.uamds.rst
+++ b/docs/uadapy.dr.uamds.rst
@@ -1,0 +1,7 @@
+uadapy.dr.uamds module
+======================
+
+.. automodule:: uadapy.dr.uamds
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.dr.uapca.rst
+++ b/docs/uadapy.dr.uapca.rst
@@ -1,0 +1,7 @@
+uadapy.dr.uapca module
+======================
+
+.. automodule:: uadapy.dr.uapca
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.dr.uapca_revisited.rst
+++ b/docs/uadapy.dr.uapca_revisited.rst
@@ -1,0 +1,7 @@
+uadapy.dr.uapca\_revisited module
+=================================
+
+.. automodule:: uadapy.dr.uapca_revisited
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.dr.vipurpca.rst
+++ b/docs/uadapy.dr.vipurpca.rst
@@ -1,0 +1,7 @@
+uadapy.dr.vipurpca module
+=========================
+
+.. automodule:: uadapy.dr.vipurpca
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.dr.wgmm_uapca.rst
+++ b/docs/uadapy.dr.wgmm_uapca.rst
@@ -1,0 +1,7 @@
+uadapy.dr.wgmm\_uapca module
+============================
+
+.. automodule:: uadapy.dr.wgmm_uapca
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.plotting.distribution_plot.rst
+++ b/docs/uadapy.plotting.distribution_plot.rst
@@ -1,0 +1,7 @@
+uadapy.plotting.distribution\_plot module
+=========================================
+
+.. automodule:: uadapy.plotting.distribution_plot
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.plotting.interactive_splom.rst
+++ b/docs/uadapy.plotting.interactive_splom.rst
@@ -1,0 +1,7 @@
+uadapy.plotting.interactive\_splom module
+=========================================
+
+.. automodule:: uadapy.plotting.interactive_splom
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.plotting.plots_1d.rst
+++ b/docs/uadapy.plotting.plots_1d.rst
@@ -1,0 +1,7 @@
+uadapy.plotting.plots\_1d module
+================================
+
+.. automodule:: uadapy.plotting.plots_1d
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.plotting.plots_2d.rst
+++ b/docs/uadapy.plotting.plots_2d.rst
@@ -1,0 +1,7 @@
+uadapy.plotting.plots\_2d module
+================================
+
+.. automodule:: uadapy.plotting.plots_2d
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.plotting.plots_nd.rst
+++ b/docs/uadapy.plotting.plots_nd.rst
@@ -1,0 +1,7 @@
+uadapy.plotting.plots\_nd module
+================================
+
+.. automodule:: uadapy.plotting.plots_nd
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.plotting.plots_timeseries.rst
+++ b/docs/uadapy.plotting.plots_timeseries.rst
@@ -1,0 +1,7 @@
+uadapy.plotting.plots\_timeseries module
+========================================
+
+.. automodule:: uadapy.plotting.plots_timeseries
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.plotting.rst
+++ b/docs/uadapy.plotting.rst
@@ -4,50 +4,23 @@ uadapy.plotting package
 Submodules
 ----------
 
-uadapy.plotting.distribution\_plot module
------------------------------------------
+.. toctree::
+   :maxdepth: 4
 
-.. automodule:: uadapy.plotting.distribution_plot
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-uadapy.plotting.interactive\_splom module
------------------------------------------
-
-.. automodule:: uadapy.plotting.interactive_splom
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-uadapy.plotting.plots2D module
-------------------------------
-
-.. automodule:: uadapy.plotting.plots2D
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-uadapy.plotting.plotsND module
-------------------------------
-
-.. automodule:: uadapy.plotting.plotsND
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-uadapy.plotting.utils module
-----------------------------
-
-.. automodule:: uadapy.plotting.utils
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   uadapy.plotting.distribution_plot
+   uadapy.plotting.interactive_splom
+   uadapy.plotting.plots_1d
+   uadapy.plotting.plots_2d
+   uadapy.plotting.plots_nd
+   uadapy.plotting.plots_timeseries
+   uadapy.plotting.shepard_diagram
+   uadapy.plotting.stippling
+   uadapy.plotting.utils
 
 Module contents
 ---------------
 
 .. automodule:: uadapy.plotting
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.plotting.shepard_diagram.rst
+++ b/docs/uadapy.plotting.shepard_diagram.rst
@@ -1,0 +1,7 @@
+uadapy.plotting.shepard\_diagram module
+=======================================
+
+.. automodule:: uadapy.plotting.shepard_diagram
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.plotting.stippling.rst
+++ b/docs/uadapy.plotting.stippling.rst
@@ -1,0 +1,7 @@
+uadapy.plotting.stippling module
+================================
+
+.. automodule:: uadapy.plotting.stippling
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.plotting.utils.rst
+++ b/docs/uadapy.plotting.utils.rst
@@ -1,0 +1,7 @@
+uadapy.plotting.utils module
+============================
+
+.. automodule:: uadapy.plotting.utils
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.rst
+++ b/docs/uadapy.rst
@@ -7,14 +7,24 @@ Subpackages
 .. toctree::
    :maxdepth: 4
 
+   uadapy.data
+   uadapy.distributions
    uadapy.dr
    uadapy.plotting
-   uadapy.data
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   uadapy.distribution
+   uadapy.timeseries
 
 Module contents
 ---------------
 
 .. automodule:: uadapy
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/uadapy.timeseries.rst
+++ b/docs/uadapy.timeseries.rst
@@ -1,0 +1,7 @@
+uadapy.timeseries module
+========================
+
+.. automodule:: uadapy.timeseries
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/uadapy/timeseries.py
+++ b/uadapy/timeseries.py
@@ -103,7 +103,7 @@ class TimeSeries:
         np.ndarray or float
             Variance of the time series.
         """
-        return self.distribution.cov().diag()
+        return self.distribution.cov().diagonal()
 
 class CorrelatedDistributions:
     """


### PR DESCRIPTION
The timeseries documentation was already available but not linked on the main page and, thus, never added to the documentation. I also reran the build for the API documentation, which automatically created all the files for the submodules.