### PR TITLE
Marginalization

### DIFF
--- a/uadapy/distribution.py
+++ b/uadapy/distribution.py
@@ -53,6 +53,7 @@ class Distribution:
         if isinstance(self.model, np.ndarray):
             self.kde = stats.gaussian_kde(self.model.T)
 
+
     def sample(self, n: int, seed: int = None) -> np.ndarray:
         """
         Creates samples from the distribution.
@@ -78,6 +79,7 @@ class Distribution:
         if hasattr(self.model, 'resample') and callable(self.model.resample):
             return self.model.resample(size=n, seed=seed)
 
+
     def pdf(self, x: np.ndarray | float) -> np.ndarray | float:
         """
         Computes the probability density function.
@@ -99,6 +101,7 @@ class Distribution:
         else:
             return self.model.pdf(x)
     
+
     def cdf(self, x: np.ndarray | float) -> np.ndarray | float:
         """
         Computes the cumulative density function.
@@ -119,6 +122,7 @@ class Distribution:
             raise AttributeError(f"The model has no cdf. {self.model.__class__.__name__}")
         else:
             return self.model.cdf(x)
+
 
     def mean(self) -> np.ndarray | float:
         """
@@ -141,6 +145,7 @@ class Distribution:
             return self.model.mu
         else:
            raise AttributeError(f"Mean not implemented yet! {self.model.__class__.__name__}")
+
 
     def cov(self) -> np.ndarray | float:
         """
@@ -186,6 +191,7 @@ class Distribution:
         if isinstance(self.model, mv.multivariate_t_frozen):
             return 0
 
+
     def kurt(self) -> np.ndarray | float:
         """
         Kurtosis of the distribution.
@@ -202,6 +208,51 @@ class Distribution:
         if isinstance(self.model, stats.multivariate_normal):
             return 0
         
+
+    def marginalize(self, dims, kde=None, n_samples_kde=1000, noise_level=0.0, seed=None):
+        """
+        Marginalizes the distribution retaining the specified dimensions.
+
+        Parameters
+        ----------
+        dims : int or list of int or ndarray
+            The dimensions to retain in the marginal distribution.
+        kde : str, optional
+            If 'KDE' or 'kde', a KDE estimation of the marginal is performed. 
+            If 'KDE?' or 'kde?', a fallback to KDE is performed if the model does not have a marginal method. 
+            Default is None, and an error is raised if the model does not have a marginal method.
+        n_samples_kde : int, optional
+            Number of samples to use for the marginal estimation via KDE. Default is 1000.
+        noise_level : float, optional
+            Level of uniform noise to be applied to the samples before KDE estimation. Default is 0.0.
+        seed : int, optional
+            Seed for the random number generator for reproducibility. Default is None.
+        """
+        if self.n_dims == 1:
+            raise IndexError("Cannot marginalize a 1D distribution. Use the sample method to get samples.")
+        if not isinstance(dims, np.ndarray):
+            dims = np.array([dims])
+        
+        # check if KDE estimation of the marginal is requested
+        if 'KDE' == kde or 'kde' == kde:
+            samples = self.sample(n_samples_kde, seed=seed)
+            samples += stats.uniform.rvs(loc=-noise_level/2, scale=noise_level, size=samples.shape, random_state=seed)
+            # update key to be the indices before the 'KDE' keyword
+            return Distribution(samples[:, dims if len(dims) > 1 else dims[0]], n_dims=len(dims))
+        # lets check if fallback KDE flag 'KDE?' / 'kde?' is present
+
+        # lets check the model if it has a `marginal` method
+        if hasattr(self.model, 'marginal') and callable(self.model.marginal):
+            return Distribution(self.model.marginal(dims if len(dims) > 1 else dims[0]), n_dims=len(dims))
+        elif isinstance(self.model, np.ndarray):
+            return Distribution(self.model[:, dims if len(dims) > 1 else dims[0]], n_dims=len(dims))
+        # fallback to KDE if specified
+        elif 'KDE?' == kde or 'kde?' == kde:
+            return self.marginalize(dims, kde='KDE', n_samples_kde=n_samples_kde, noise_level=noise_level, seed=seed)
+        else:
+            raise NotImplementedError(f"Marginal distribution not implemented for {self.model.__class__.__name__}")
+
+
     def __getitem__(self, key):
         """
         Allows indexing into the distribution's dimensions.
@@ -220,9 +271,6 @@ class Distribution:
         Distribuition
             The marginal distribution corresponding to the specified dimensions. 
         """
-        if self.n_dims == 1:
-            raise IndexError("Cannot marginalize a 1D distribution. Use the sample method to get samples.")
-
         # turn key into a list if it is not already
         if isinstance(key, (int, np.int_)):
             key = [key]
@@ -231,45 +279,31 @@ class Distribution:
             key = list(range(start, stop, step))
         if isinstance(key, tuple):
             key = list(key)
-        # now check if the key is a list
-        if not isinstance(key, list):
-            raise TypeError("Invalid index type. Must be int, slice, list or tuple.")
-        
-        # check if key contains 'KDE' or 'kde' then the argument following it is the number of samples to use for the marginal estimation via KDE
+        # now check if key is list or ndarray
+        if not isinstance(key, (list, np.ndarray)):
+            raise TypeError("Invalid index type. Must be int, slice, list, tuple, or ndarray.")
+
+        # check if key contains 'KDE' or 'kde' or 'KDE?' or 'kde?'. 
+        # Then the argument following it is the number of samples to use for the marginal estimation via KDE
         # and if there is another argument, it is the level of noise to be applied, 
-        # and if there is another argument, it is the seed for the random number generator
-        if 'KDE' in key or 'kde' in key:
-            kde_index = key.index('KDE') if 'KDE' in key else key.index('kde')
-            n_samples = 1000
+        # and if there is yet another argument, it is the seed for the random number generator
+        kde_index = None
+        for i, k in enumerate(key):
+            if k in ['KDE', 'kde', 'KDE?', 'kde?']:
+                kde_index = i
+                break
+        if kde_index is not None:
+            kde_flag = key[kde_index]
+            n_samples_kde = 1000
             noise_level = 0.0
             seed = None
-            if kde_index + 1 < len(key):
-                n_samples = key[kde_index + 1]
-            if kde_index + 2 < len(key):
+            if len(key) > kde_index + 1:
+                n_samples_kde = key[kde_index + 1]
+            if len(key) > kde_index + 2:
                 noise_level = key[kde_index + 2]
-            if kde_index + 3 < len(key):
+            if len(key) > kde_index + 3:
                 seed = key[kde_index + 3]
-            samples = self.sample(n_samples, seed=seed)
-            samples += stats.uniform.rvs(loc=-noise_level/2, scale=noise_level, size=samples.shape, random_state=seed)
-            # update key to be the indices before the 'KDE' keyword
+            # remove the kde flag and its parameters from the key
             key = key[:kde_index]
-            return Distribution(samples[:, key if len(key) > 1 else key[0]], n_dims=len(key))
-
-        # lets check if fallback KDE flag 'KDE?' / 'kde?' is present
-        kde_index = None
-        if 'KDE?' in key or 'kde?' in key:
-            kde_index = key.index('KDE?') if 'KDE?' in key else key.index('kde?')
-            # update key to be the indices before the 'KDE?' keyword
-            key = key[:kde_index]
-
-        # lets check the model if it has a `marginal` method
-        if hasattr(self.model, 'marginal') and callable(self.model.marginal):
-            return Distribution(self.model.marginal(key if len(key) > 1 else key[0]), n_dims=len(key))
-        elif isinstance(self.model, np.ndarray):
-            return Distribution(self.model[:, key if len(key) > 1 else key[0]], n_dims=len(key))
-        # fallback to KDE if specified
-        elif kde_index is not None:
-            key[kde_index] = 'KDE'
-            return self.__getitem__(key)
-        else:
-            raise NotImplementedError(f"Marginal distribution not implemented for {self.model.__class__.__name__}")
+            return self.marginalize(key, kde=kde_flag, n_samples_kde=n_samples_kde, noise_level=noise_level, seed=seed)
+        return self.marginalize(key)

--- a/uadapy/distribution.py
+++ b/uadapy/distribution.py
@@ -201,3 +201,75 @@ class Distribution:
             return self.model.stats(moments='k')
         if isinstance(self.model, stats.multivariate_normal):
             return 0
+        
+    def __getitem__(self, key):
+        """
+        Allows indexing into the distribution's dimensions.
+        This yields the corresponding marginal distribution.
+
+        Parameters
+        ----------
+        key : int or slice or tuple or list
+            Index or slice to access dimensions of the distribution.
+            In case the underlying model does not provide a marginalization function, a KDE can be used to estimate the marginal distribution. 
+            Then, the key needs to contain the keyword 'KDE' followed by the number of samples to use for the marginal estimation via KDE, the level of noise to be applied, and the seed for the random number generator.
+            Example: distrib[0, 1, 'KDE', 1000] or distrib[0, 1, 'KDE', 1000, 0.1, 42]
+
+        Returns
+        -------
+        Distribuition
+            The marginal distribution corresponding to the specified dimensions. 
+        """
+        if self.n_dims == 1:
+            raise IndexError("Cannot marginalize a 1D distribution. Use the sample method to get samples.")
+
+        # turn key into a list if it is not already
+        if isinstance(key, (int, np.int_)):
+            key = [key]
+        if isinstance(key, slice):
+            start, stop, step = key.indices(self.n_dims)
+            key = list(range(start, stop, step))
+        if isinstance(key, tuple):
+            key = list(key)
+        # now check if the key is a list
+        if not isinstance(key, list):
+            raise TypeError("Invalid index type. Must be int, slice, list or tuple.")
+        
+        # check if key contains 'KDE' or 'kde' then the argument following it is the number of samples to use for the marginal estimation via KDE
+        # and if there is another argument, it is the level of noise to be applied, 
+        # and if there is another argument, it is the seed for the random number generator
+        if 'KDE' in key or 'kde' in key:
+            kde_index = key.index('KDE') if 'KDE' in key else key.index('kde')
+            n_samples = 1000
+            noise_level = 0.0
+            seed = None
+            if kde_index + 1 < len(key):
+                n_samples = key[kde_index + 1]
+            if kde_index + 2 < len(key):
+                noise_level = key[kde_index + 2]
+            if kde_index + 3 < len(key):
+                seed = key[kde_index + 3]
+            samples = self.sample(n_samples, seed=seed)
+            samples += stats.uniform.rvs(loc=-noise_level/2, scale=noise_level, size=samples.shape, random_state=seed)
+            # update key to be the indices before the 'KDE' keyword
+            key = key[:kde_index]
+            return Distribution(samples[:, key if len(key) > 1 else key[0]], n_dims=len(key))
+
+        # lets check if fallback KDE flag 'KDE?' / 'kde?' is present
+        kde_index = None
+        if 'KDE?' in key or 'kde?' in key:
+            kde_index = key.index('KDE?') if 'KDE?' in key else key.index('kde?')
+            # update key to be the indices before the 'KDE?' keyword
+            key = key[:kde_index]
+
+        # lets check the model if it has a `marginal` method
+        if hasattr(self.model, 'marginal') and callable(self.model.marginal):
+            return Distribution(self.model.marginal(key if len(key) > 1 else key[0]), n_dims=len(key))
+        elif isinstance(self.model, np.ndarray):
+            return Distribution(self.model[:, key if len(key) > 1 else key[0]], n_dims=len(key))
+        # fallback to KDE if specified
+        elif kde_index is not None:
+            key[kde_index] = 'KDE'
+            return self.__getitem__(key)
+        else:
+            raise NotImplementedError(f"Marginal distribution not implemented for {self.model.__class__.__name__}")

--- a/uadapy/distribution.py
+++ b/uadapy/distribution.py
@@ -209,7 +209,7 @@ class Distribution:
             return 0
         
 
-    def marginalize(self, dims, kde=None, n_samples_kde=1000, noise_level=0.0, seed=None):
+    def marginal(self, dims, kde=None, n_samples_kde=1000, noise_level=0.0, seed=None):
         """
         Marginalizes the distribution retaining the specified dimensions.
 
@@ -248,7 +248,7 @@ class Distribution:
             return Distribution(self.model[:, dims if len(dims) > 1 else dims[0]], n_dims=len(dims))
         # fallback to KDE if specified
         elif 'KDE?' == kde or 'kde?' == kde:
-            return self.marginalize(dims, kde='KDE', n_samples_kde=n_samples_kde, noise_level=noise_level, seed=seed)
+            return self.marginal(dims, kde='KDE', n_samples_kde=n_samples_kde, noise_level=noise_level, seed=seed)
         else:
             raise NotImplementedError(f"Marginal distribution not implemented for {self.model.__class__.__name__}. You may want to use the 'KDE' flag to estimate the marginal distribution via KDE.")
 
@@ -309,5 +309,5 @@ class Distribution:
             key = key[:kde_index]
             if len(key) == 1:
                 key = key[0]
-            return self.marginalize(key, kde=kde_flag, n_samples_kde=n_samples_kde, noise_level=noise_level, seed=seed)
+            return self.marginal(key, kde=kde_flag, n_samples_kde=n_samples_kde, noise_level=noise_level, seed=seed)
         return self.marginalize(key)

--- a/uadapy/distribution.py
+++ b/uadapy/distribution.py
@@ -250,7 +250,7 @@ class Distribution:
         elif 'KDE?' == kde or 'kde?' == kde:
             return self.marginalize(dims, kde='KDE', n_samples_kde=n_samples_kde, noise_level=noise_level, seed=seed)
         else:
-            raise NotImplementedError(f"Marginal distribution not implemented for {self.model.__class__.__name__}")
+            raise NotImplementedError(f"Marginal distribution not implemented for {self.model.__class__.__name__}. You may want to use the 'KDE' flag to estimate the marginal distribution via KDE.")
 
 
     def __getitem__(self, key):
@@ -263,8 +263,10 @@ class Distribution:
         key : int or slice or tuple or list
             Index or slice to access dimensions of the distribution.
             In case the underlying model does not provide a marginalization function, a KDE can be used to estimate the marginal distribution. 
-            Then, the key needs to contain the keyword 'KDE' followed by the number of samples to use for the marginal estimation via KDE, the level of noise to be applied, and the seed for the random number generator.
+            Then, the key needs to contain the keyword 'KDE' followed by the number of samples to use for the marginal estimation via KDE, 
+            the level of noise to be applied, and the seed for the random number generator.
             Example: distrib[0, 1, 'KDE', 1000] or distrib[0, 1, 'KDE', 1000, 0.1, 42]
+            Using the 'KDE?' or 'kde?' keyword will fallback to KDE if the underlying model does not provide a marginalization function.
 
         Returns
         -------
@@ -305,5 +307,7 @@ class Distribution:
                 seed = key[kde_index + 3]
             # remove the kde flag and its parameters from the key
             key = key[:kde_index]
+            if len(key) == 1:
+                key = key[0]
             return self.marginalize(key, kde=kde_flag, n_samples_kde=n_samples_kde, noise_level=noise_level, seed=seed)
         return self.marginalize(key)

--- a/uadapy/distributions/multivariate_gmm.py
+++ b/uadapy/distributions/multivariate_gmm.py
@@ -1,6 +1,7 @@
 import numpy as np
 from sklearn.mixture import GaussianMixture
-from scipy.stats import gaussian_kde
+from scipy.stats import gaussian_kde, Mixture, Normal
+from sklearn.mixture._gaussian_mixture import _compute_precision_cholesky
 
 
 class MultivariateGMM:
@@ -79,7 +80,7 @@ class MultivariateGMM:
         """
         if seed is not None:
             # Create temporary random state without modifying the model
-            rng = np.random.RandomState(seed)
+            rng = np.random.RandomState(seed) # TODO: why use RandomState(seed) instead of default_rng(seed)?
             
             # Sample component indices according to mixture weights
             component_indices = rng.choice(
@@ -195,6 +196,43 @@ class MultivariateGMM:
             return full_covs
         else:
             raise ValueError(f"Unknown covariance type: {cov_type}")
+        
+
+    def marginal(self, dimensions):
+        """
+        Computes the marginal distribution over specified dimensions.
+
+        Parameters
+        ----------
+        dimensions : list of int or int
+            Indices of the dimensions to keep.
+
+        Returns
+        -------
+        MultivariateGMM or Mixture
+            A new MultivariateGMM representing the marginal distribution.
+            In case of a single dimension, returns a univariate scipy.stats.Mixture of Normals.
+        """
+        if np.asarray(dimensions).size > 1:
+            # Extract means and covariances for the specified dimensions
+            new_means = self.means_[:, dimensions]
+            new_covariances = self.covariances_[:, *np.ix_(dimensions, dimensions)]
+            
+            # Create a new GaussianMixture with the same weights
+            new_gmm = GaussianMixture(n_components=self.n_components, covariance_type="full")
+            new_gmm.weights_ = self.weights_
+            new_gmm.means_ = new_means
+            new_gmm.covariances_ = new_covariances
+            new_gmm.precisions_cholesky_ = _compute_precision_cholesky(new_covariances, "full")
+            return MultivariateGMM(new_gmm)
+        else:
+            dim = np.asarray(dimensions).item()
+            # for single dimension, return a univariate GMM
+            new_means = self.means_[:, dim]
+            new_variances = self.covariances_[:, dim, dim]
+            return Mixture([Normal(mu=new_means[i], sigma=new_variances[i]) for i in range(new_means.size)], weights=self.weights_)
+            
+
 
 
 def gmm_from_kde(kde: gaussian_kde):
@@ -219,5 +257,7 @@ def gmm_from_kde(kde: gaussian_kde):
     gmm.weights_ = kde.weights
     gmm.means_ = centers
     gmm.covariances_ = np.array([kde.covariance for _ in range(n_components)])
+    gmm.precisions_cholesky_ = _compute_precision_cholesky(gmm.covariances_, "full")
+
 
     return MultivariateGMM(gmm)

--- a/uadapy/distributions/multivariate_gmm.py
+++ b/uadapy/distributions/multivariate_gmm.py
@@ -216,7 +216,8 @@ class MultivariateGMM:
         if np.asarray(dimensions).size > 1:
             # Extract means and covariances for the specified dimensions
             new_means = self.means_[:, dimensions]
-            new_covariances = self.covariances_[:, *np.ix_(dimensions, dimensions)]
+            idx0, idx1 = np.ix_(dimensions, dimensions)
+            new_covariances = self.covariances_[:, idx0, idx1]
             
             # Create a new GaussianMixture with the same weights
             new_gmm = GaussianMixture(n_components=self.n_components, covariance_type="full")

--- a/uadapy/plotting/plots_nd.py
+++ b/uadapy/plotting/plots_nd.py
@@ -324,9 +324,7 @@ def plot_contour(distributions,
         for x, y in [(i, j), (j, i)]:
             if not plot_mask[y,x]:
                 continue # skip
-            #dists2d = [Distribution(distrib_samples[k][:,[x,y]]) for k in range(len(distributions))]
             dists2d = [d[x,y, 'KDE?', n_samples_kde, 2e-8, seed] for d in distributions]
-            [d[[x,y]] for d in distributions]
             plots_2d.plot_contour(dists2d, resolution=resolution, ranges=ranges, quantiles=quantiles, 
                 fig=fig, axs=axs[y,x],distrib_colors=distrib_colors, colorblind_safe=colorblind_safe,
                 show_plot=False)

--- a/uadapy/plotting/plots_nd.py
+++ b/uadapy/plotting/plots_nd.py
@@ -324,7 +324,9 @@ def plot_contour(distributions,
         for x, y in [(i, j), (j, i)]:
             if not plot_mask[y,x]:
                 continue # skip
-            dists2d = [Distribution(distrib_samples[k][:,[x,y]]) for k in range(len(distributions))]
+            #dists2d = [Distribution(distrib_samples[k][:,[x,y]]) for k in range(len(distributions))]
+            dists2d = [d[x,y, 'KDE?', n_samples_kde, 2e-8, seed] for d in distributions]
+            [d[[x,y]] for d in distributions]
             plots_2d.plot_contour(dists2d, resolution=resolution, ranges=ranges, quantiles=quantiles, 
                 fig=fig, axs=axs[y,x],distrib_colors=distrib_colors, colorblind_safe=colorblind_safe,
                 show_plot=False)
@@ -333,7 +335,8 @@ def plot_contour(distributions,
     for i in range(n_dims):
         if not plot_mask[i,i]:
             continue
-        dists1d = [Distribution(distrib_samples[k][:,i]) for k in range(len(distributions))]
+        #dists1d = [Distribution(distrib_samples[k][:,i]) for k in range(len(distributions))]
+        dists1d = [d[i, 'KDE?', n_samples_kde, 2e-8, seed] for d in distributions]
         range_global = np.vstack(distrib_samples)[:,i].min(), np.vstack(distrib_samples)[:,i].max()
         x_global = np.linspace(range_global[0],range_global[1], num=resolution)
         for k in range(len(distributions)):


### PR DESCRIPTION
Issue #64 holds the discussion of this feature.

This pull request introduces marginalization capabilities. It also updates the plotting code to leverage these new features, making marginalization and KDE estimation more accessible.

**Major enhancements to distribution marginalization and plotting:**

### Distribution marginalization and indexing

* Added a `marginalize` method to the `Distribution` class, enabling users to obtain marginal distributions along specified dimensions, with options for KDE-based estimation, noise injection, and reproducibility via random seed. This method gracefully handles models that do not natively support marginalization, including fallback strategies.
* Implemented the `__getitem__` method for the `Distribution` class, allowing intuitive indexing and slicing to extract marginal distributions. Special keywords ('KDE', 'KDE?') and parameters can be passed to control marginalization behavior, making the API more flexible.

### Plotting improvements

* Updated `plot_contour` in `uadapy/plotting/plots_nd.py` to utilize the new marginalization interface. Instead of relying on estimates of the marginal via sampling + KDE, the code now uses the enhanced `Distribution` indexing with KDE fallback, improving reliability and consistency in plotting 1D and 2D marginals.
